### PR TITLE
cargo teleporter bank integration

### DIFF
--- a/Content.Server/Cargo/Systems/CargoSystem.Orders.cs
+++ b/Content.Server/Cargo/Systems/CargoSystem.Orders.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using Content.Server.Access.Systems;
+using Content.Server.Bank;
 using Content.Server.Cargo.Components;
 using Content.Server.Labels.Components;
 using Content.Server.MachineLinking.System;
@@ -7,6 +8,7 @@ using Content.Server.Popups;
 using Content.Server.Station.Systems;
 using Content.Shared.Access.Systems;
 using Content.Shared.Administration.Logs;
+using Content.Shared.Bank.Components;
 using Content.Shared.Cargo;
 using Content.Shared.Cargo.BUI;
 using Content.Shared.Cargo.Events;
@@ -17,6 +19,7 @@ using Content.Server.Paper;
 using Robust.Server.GameObjects;
 using Robust.Shared.Map;
 using Robust.Shared.Players;
+using System.Linq;
 
 namespace Content.Server.Cargo.Systems
 {
@@ -34,6 +37,7 @@ namespace Content.Server.Cargo.Systems
 
         [Dependency] private readonly IdCardSystem _idCardSystem = default!;
         [Dependency] private readonly AccessReaderSystem _accessReaderSystem = default!;
+        [Dependency] private readonly BankSystem _bankSystem = default!;
         [Dependency] private readonly SignalLinkerSystem _linker = default!;
         [Dependency] private readonly PopupSystem _popup = default!;
         [Dependency] private readonly StationSystem _station = default!;
@@ -105,7 +109,7 @@ namespace Content.Server.Cargo.Systems
             }
 
             var orderDatabase = GetOrderDatabase(component);
-            var bankAccount = GetBankAccount(component);
+            if (!TryComp<BankAccountComponent>(player, out var bankAccount)) return;
 
             // No station to deduct from.
             if (orderDatabase == null || bankAccount == null)
@@ -168,8 +172,12 @@ namespace Content.Server.Cargo.Systems
             // Log order approval
             _adminLogger.Add(LogType.Action, LogImpact.Low,
                 $"{ToPrettyString(player):user} approved order [orderId:{order.OrderId}, quantity:{order.OrderQuantity}, product:{order.ProductId}, requester:{order.Requester}, reason:{order.Reason}] with balance at {bankAccount.Balance}");
+            if (TryComp<StationBankAccountComponent>(_station.GetOwningStation(uid), out var stationBank))
+            {
+                DeductFunds(stationBank, -(cost / 2));
+            }
+            _bankSystem.TryBankWithdraw(player, cost);
 
-            DeductFunds(bankAccount, cost);
             UpdateOrders(orderDatabase);
         }
 
@@ -189,7 +197,8 @@ namespace Content.Server.Cargo.Systems
                 return;
 
             var bank = GetBankAccount(component);
-            if (bank == null) return;
+            
+            if (!HasComp<BankAccountComponent>(player) && bank == null) return;
             var orderDatabase = GetOrderDatabase(component);
             if (orderDatabase == null) return;
 
@@ -217,18 +226,37 @@ namespace Content.Server.Cargo.Systems
 
         private void UpdateOrderState(CargoOrderConsoleComponent component, EntityUid? station)
         {
-            if (station == null ||
-                !TryComp<StationCargoOrderDatabaseComponent>(station, out var orderDatabase) ||
-                !TryComp<StationBankAccountComponent>(station, out var bankAccount)) return;
+            var bui = _uiSystem.GetUi(component.Owner, CargoConsoleUiKey.Orders);
+            var uiUser = bui.SubscribedSessions.FirstOrDefault();
+            var balance = 0;
+
+            if (uiUser?.AttachedEntity is not { Valid: true } player)
+            {
+                return;
+            }
+
+            if (Transform(component.Owner).GridUid is EntityUid stationGrid && TryComp<BankAccountComponent>(player, out var playerBank))
+            {
+                station = stationGrid;
+                balance = playerBank.Balance;
+            }
+            else if (TryComp<StationBankAccountComponent>(station, out var stationBank))
+            {
+                balance = stationBank.Balance;
+            }
+
+            if (station == null) return;
+            
+            if (GetOrderDatabase(component) is not StationCargoOrderDatabaseComponent orderDatabase) return;
 
             var state = new CargoConsoleInterfaceState(
-                MetaData(station.Value).EntityName,
+                MetaData(player).EntityName,
                 GetOutstandingOrderCount(orderDatabase),
                 orderDatabase.Capacity,
-                bankAccount.Balance,
+                balance,
                 orderDatabase.Orders);
 
-            _uiSystem.GetUiOrNull(component.Owner, CargoConsoleUiKey.Orders)?.SetState(state);
+            _uiSystem.SetUiState(bui, state);
         }
 
         private void ConsolePopup(ICommonSession session, string text) => _popup.PopupCursor(text, session);
@@ -267,7 +295,13 @@ namespace Content.Server.Cargo.Systems
 
             while (orderQuery.MoveNext(out var uid, out var comp))
             {
-                var station = _station.GetOwningStation(uid);
+                var station = Transform(uid).GridUid;
+
+                if (_station.GetOwningStation(uid) is EntityUid stationComp)
+                {
+                    station = stationComp;
+                }
+
                 if (station != component.Owner)
                     continue;
 
@@ -277,7 +311,13 @@ namespace Content.Server.Cargo.Systems
             var consoleQuery = AllEntityQuery<CargoShuttleConsoleComponent>();
             while (consoleQuery.MoveNext(out var uid, out var comp))
             {
-                var station = _station.GetOwningStation(uid);
+                var station = Transform(uid).GridUid;
+
+                if (_station.GetOwningStation(uid) is EntityUid stationComp)
+                {
+                    station = stationComp;
+                }
+
                 if (station != component.Owner)
                     continue;
 
@@ -393,7 +433,12 @@ namespace Content.Server.Cargo.Systems
 
         private StationCargoOrderDatabaseComponent? GetOrderDatabase(CargoOrderConsoleComponent component)
         {
-            var station = _station.GetOwningStation(component.Owner);
+            var station = Transform(component.Owner).GridUid;
+
+            if (_station.GetOwningStation(component.Owner) is EntityUid stationComp)
+            {
+                station = stationComp;
+            }
 
             TryComp<StationCargoOrderDatabaseComponent>(station, out var orderComponent);
             return orderComponent;

--- a/Content.Server/Cargo/Systems/CargoSystem.Shuttle.cs
+++ b/Content.Server/Cargo/Systems/CargoSystem.Shuttle.cs
@@ -9,6 +9,7 @@ using Content.Server.Shuttles.Systems;
 using Content.Server.Station.Components;
 using Content.Server.Stack;
 using Content.Shared.Stacks;
+using Content.Shared.Bank.Components;
 using Content.Shared.Cargo;
 using Content.Shared.Cargo.BUI;
 using Content.Shared.Cargo.Components;
@@ -189,6 +190,10 @@ public sealed partial class CargoSystem
             return;
         }
         GetPalletGoods(gridUid, out var toSell, out var amount);
+        if (TryComp<MarketModifierComponent>(uid, out var priceMod))
+        {
+            amount *= priceMod.Mod;
+        }
         _uiSystem.SetUiState(bui,
             new CargoPalletConsoleInterfaceState((int) amount, toSell.Count, true));
     }
@@ -445,6 +450,10 @@ public sealed partial class CargoSystem
         }
 
         SellPallets(gridUid, out var price);
+        if (TryComp<MarketModifierComponent>(uid, out var priceMod))
+        {
+            price *= priceMod.Mod;
+        }
         var stackPrototype = _prototypeManager.Index<StackPrototype>(component.CashType);
         _stack.Spawn((int)price, stackPrototype, uid.ToCoordinates());
         UpdatePalletConsoleInterface(uid, component);

--- a/Content.Server/Stack/StackSystem.cs
+++ b/Content.Server/Stack/StackSystem.cs
@@ -16,7 +16,7 @@ namespace Content.Server.Stack
     {
         [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
 
-        public static readonly int[] DefaultSplitAmounts = { 1, 5, 10, 20, 30, 50 };
+        public static readonly int[] DefaultSplitAmounts = { 1, 5, 10, 20, 50, 100, 500, 1000, 5000, 10000 };
 
         public override void Initialize()
         {

--- a/Resources/Prototypes/Catalog/Cargo/cargo_armory.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_armory.yml
@@ -1,22 +1,22 @@
-- type: cargoProduct
-  id: ArmorySmg
-  icon:
-    sprite: Objects/Weapons/Guns/SMGs/wt550.rsi
-    state: icon
-  product: CrateArmorySMG
-  cost: 3000
-  category: Armory
-  group: market
+# - type: cargoProduct
+  # id: ArmorySmg
+  # icon:
+    # sprite: Objects/Weapons/Guns/SMGs/wt550.rsi
+    # state: icon
+  # product: CrateArmorySMG
+  # cost: 3000
+  # category: Armory
+  # group: market
 
-- type: cargoProduct
-  id: ArmoryShotgun
-  icon:
-    sprite: Objects/Weapons/Guns/Shotguns/enforcer.rsi
-    state: icon
-  product: CrateArmoryShotgun
-  cost: 2500
-  category: Armory
-  group: market
+# - type: cargoProduct
+  # id: ArmoryShotgun
+  # icon:
+    # sprite: Objects/Weapons/Guns/Shotguns/enforcer.rsi
+    # state: icon
+  # product: CrateArmoryShotgun
+  # cost: 2500
+  # category: Armory
+  # group: market
 
 - type: cargoProduct
   id: TrackingImplant
@@ -28,12 +28,12 @@
   category: Armory
   group: market
 
-- type: cargoProduct
-  id: ArmoryLaser
-  icon:
-    sprite: Objects/Weapons/Guns/Battery/laser_retro.rsi
-    state: icon
-  product: CrateArmoryLaser
-  cost: 1600
-  category: Armory
-  group: market
+# - type: cargoProduct
+  # id: ArmoryLaser
+  # icon:
+    # sprite: Objects/Weapons/Guns/Battery/laser_retro.rsi
+    # state: icon
+  # product: CrateArmoryLaser
+  # cost: 1600
+  # category: Armory
+  # group: market

--- a/Resources/Prototypes/Catalog/Cargo/cargo_food.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_food.yml
@@ -1,22 +1,22 @@
-- type: cargoProduct
-  id: FoodPizza
-  icon:
-    sprite: Objects/Consumable/Food/Baked/pizza.rsi
-    state: margherita
-  product: CrateFoodPizza
-  cost: 450
-  category: Food
-  group: market
+# - type: cargoProduct
+  # id: FoodPizza
+  # icon:
+    # sprite: Objects/Consumable/Food/Baked/pizza.rsi
+    # state: margherita
+  # product: CrateFoodPizza
+  # cost: 450
+  # category: Food
+  # group: market
 
-- type: cargoProduct
-  id: FoodMRE
-  icon:
-    sprite: Objects/Consumable/Food/snacks.rsi
-    state: nutribrick
-  product: CrateFoodMRE
-  cost: 1000
-  category: Food
-  group: market
+# - type: cargoProduct
+  # id: FoodMRE
+  # icon:
+    # sprite: Objects/Consumable/Food/snacks.rsi
+    # state: nutribrick
+  # product: CrateFoodMRE
+  # cost: 1000
+  # category: Food
+  # group: market
 
 - type: cargoProduct
   id: FoodCook

--- a/Resources/Prototypes/Catalog/Cargo/cargo_security.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_security.yml
@@ -1,69 +1,69 @@
-- type: cargoProduct
-  id: SecurityArmor
-  icon:
-    sprite: Clothing/OuterClothing/Vests/oldarmor.rsi
-    state: icon
-  product: CrateSecurityArmor
-  cost: 700
-  category: Security
-  group: market
+# - type: cargoProduct
+  # id: SecurityArmor
+  # icon:
+    # sprite: Clothing/OuterClothing/Vests/oldarmor.rsi
+    # state: icon
+  # product: CrateSecurityArmor
+  # cost: 700
+  # category: Security
+  # group: market
 
-- type: cargoProduct
-  id: SecurityHelmet
-  icon:
-    sprite: Clothing/Head/Helmets/security.rsi
-    state: icon
-  product: CrateSecurityHelmet
-  cost: 550
-  category: Security
-  group: market
+# - type: cargoProduct
+  # id: SecurityHelmet
+  # icon:
+    # sprite: Clothing/Head/Helmets/security.rsi
+    # state: icon
+  # product: CrateSecurityHelmet
+  # cost: 550
+  # category: Security
+  # group: market
 
-- type: cargoProduct
-  id: SecurityNonLethal
-  icon:
-    sprite: Objects/Weapons/Guns/Battery/disabler.rsi
-    state: base
-  product: CrateSecurityNonlethal
-  cost: 2100
-  category: Security
-  group: market
+# - type: cargoProduct
+  # id: SecurityNonLethal
+  # icon:
+    # sprite: Objects/Weapons/Guns/Battery/disabler.rsi
+    # state: base
+  # product: CrateSecurityNonlethal
+  # cost: 2100
+  # category: Security
+  # group: market
 
-- type: cargoProduct
-  id: SecurityRiot
-  icon:
-    sprite: Clothing/OuterClothing/Armor/riot.rsi
-    state: icon
-  product: CrateSecurityRiot
-  cost: 2900
-  category: Security
-  group: market
+# - type: cargoProduct
+  # id: SecurityRiot
+  # icon:
+    # sprite: Clothing/OuterClothing/Armor/riot.rsi
+    # state: icon
+  # product: CrateSecurityRiot
+  # cost: 2900
+  # category: Security
+  # group: market
 
-- type: cargoProduct
-  id: SecuritySupplies
-  icon:
-    sprite: Objects/Storage/boxes.rsi
-    state: box_security
-  product: CrateSecuritySupplies
-  cost: 500
-  category: Security
-  group: market
+# - type: cargoProduct
+  # id: SecuritySupplies
+  # icon:
+    # sprite: Objects/Storage/boxes.rsi
+    # state: box_security
+  # product: CrateSecuritySupplies
+  # cost: 500
+  # category: Security
+  # group: market
 
-- type: cargoProduct
-  id: SecurityRestraints
-  icon:
-    sprite: Objects/Misc/handcuffs.rsi
-    state: handcuff
-  product: CrateRestraints
-  cost: 1000
-  category: Security
-  group: market
+# - type: cargoProduct
+  # id: SecurityRestraints
+  # icon:
+    # sprite: Objects/Misc/handcuffs.rsi
+    # state: handcuff
+  # product: CrateRestraints
+  # cost: 1000
+  # category: Security
+  # group: market
 
-- type: cargoProduct
-  id: SecurityBiosuit
-  icon:
-    sprite: Clothing/Head/Hoods/Bio/security.rsi
-    state: icon
-  product: CrateSecurityBiosuit
-  cost: 800
-  category: Security
-  group: market
+# - type: cargoProduct
+  # id: SecurityBiosuit
+  # icon:
+    # sprite: Clothing/Head/Hoods/Bio/security.rsi
+    # state: icon
+  # product: CrateSecurityBiosuit
+  # cost: 800
+  # category: Security
+  # group: market

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/ammo.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/ammo.yml
@@ -1,27 +1,16 @@
 ﻿- type: vendingMachineInventory
   id: AmmoVendInventory
   startingInventory:
-    MagazineBoxCaselessRifle: 3
-    MagazineBoxCaselessRifleHighVelocity: 3
-    MagazineBoxCaselessRiflePractice: 3
-    MagazineBoxCaselessRifleRubber: 3
+    WeaponLaserGun: 5
 
-    MagazineBoxLightRifleBig: 3
-    MagazineBoxLightRifleHighVelocity: 3
-    MagazineBoxLightRiflePractice: 3
-    MagazineBoxLightRifleRubber: 3
+    WeaponSniperMosin: 5
+    MagazineBoxLightRifleBig: 5
+    MagazineBoxLightRiflePractice: 5
+    MagazineBoxLightRifleRubber: 5
+   
+    WeaponShotgunDoubleBarreled: 5
+    BoxLethalshot: 5
+    BoxBeanbag: 5
+    BoxShellTranquilizer: 5
+    BoxShotgunPractice: 5    
 
-    MagazineBoxMagnum: 3
-    MagazineBoxMagnumHighVelocity: 3
-    MagazineBoxMagnumPractice: 3
-    MagazineBoxMagnumRubber: 3
-
-    MagazineBoxPistol: 3
-    MagazineBoxPistolHighVelocity: 3
-    MagazineBoxPistolPractice: 3
-    MagazineBoxPistolRubber: 3
-
-    MagazineBoxRifle: 3
-    MagazineBoxRifleHighVelocity: 3
-    MagazineBoxRiflePractice: 3
-    MagazineBoxRifleRubber: 3

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -46,7 +46,7 @@
     - Belt
 
 - type: entity
-  name: retro laser gun
+  name: laser pistol
   parent: BaseWeaponBatterySmall
   id: WeaponLaserGun
   description: A weapon using light amplified by the stimulated emission of radiation.
@@ -67,6 +67,8 @@
     steps: 5
     zeroVisible: true
   - type: Appearance
+  - type: StaticPrice
+    price: 150
 
 - type: entity
   name: makeshift laser gun

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
@@ -117,6 +117,8 @@
     graph: ShotgunSawn
     node: start
     deconstructionTarget: null
+  - type: StaticPrice
+    price: 325
 
 - type: entity
   name: Enforcer

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
@@ -47,6 +47,8 @@
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Snipers/bolt_gun_wood.rsi
+  - type: StaticPrice
+    price: 275
 
 - type: entity
   name: Hristov

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
@@ -676,8 +676,8 @@
     radius: 1.5
     energy: 1.6
     color: "#b89f25"
-  - type: AccessReader
-    access: [["Cargo"]]
+  # - type: AccessReader
+    # access: [["Cargo"]]
 
 - type: entity
   parent: BaseComputer

--- a/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
@@ -125,6 +125,8 @@
       shader: unshaded
     - state: panel
       map: ["enum.WiresVisualLayers.MaintenancePanel"]
+  - type: MarketModifier
+    mod: 11.132
 
 - type: entity
   parent: VendingMachine
@@ -152,8 +154,8 @@
       shader: unshaded
     - state: panel
       map: ["enum.WiresVisualLayers.MaintenancePanel"]
-  - type: AccessReader
-    access: [["Bar"]]
+  - type: MarketModifier
+    mod: 5
 
 - type: entity
   parent: VendingMachine
@@ -184,6 +186,8 @@
     color: "#ffb0b0"
   - type: AccessReader
     access: [["HeadOfPersonnel"]]
+  - type: MarketModifier
+    mod: 5
 
 - type: entity
   parent: VendingMachine
@@ -209,12 +213,12 @@
       shader: unshaded
     - state: panel
       map: ["enum.WiresVisualLayers.MaintenancePanel"]
-  - type: AccessReader
-    access: [["Service"]]
   - type: PointLight
     radius: 1.5
     energy: 1.6
     color: "#4b93ad"
+  - type: MarketModifier
+    mod: 5
 
 - type: entity
   parent: VendingMachine
@@ -552,12 +556,12 @@
       shader: unshaded
     - state: panel
       map: ["enum.WiresVisualLayers.MaintenancePanel"]
-  - type: AccessReader
-    access: [["Service"]]
   - type: PointLight
     radius: 1.5
     energy: 1.6
     color: "#4b93ad"
+  - type: MarketModifier
+    mod: 5
 
 - type: entity
   parent: VendingMachine
@@ -641,13 +645,13 @@
       shader: unshaded
     - state: panel
       map: ["enum.WiresVisualLayers.MaintenancePanel"]
-  - type: AccessReader
-    access: [["Engineering"]]
   - type: PointLight
     radius: 1.5
     energy: 1.6
     color: "#b89e2a"
-
+  - type: MarketModifier
+    mod: 5
+    
 - type: entity
   parent: VendingMachine
   id: VendingMachineMedical
@@ -674,8 +678,8 @@
       shader: unshaded
     - state: panel
       map: ["enum.WiresVisualLayers.MaintenancePanel"]
-  - type: AccessReader
-    access: [["Medical"]]
+  - type: MarketModifier
+    mod: 5
   - type: PointLight
     radius: 1.5
     energy: 1.6
@@ -706,8 +710,8 @@
       shader: unshaded
     - state: panel
       map: ["enum.WiresVisualLayers.MaintenancePanel"]
-  - type: AccessReader
-    access: [["Hydroponics"]]
+  - type: MarketModifier
+    mod: 5
   - type: PointLight
     radius: 1.5
     energy: 1.6
@@ -740,6 +744,8 @@
       map: ["enum.WiresVisualLayers.MaintenancePanel"]
   - type: AccessReader
     access: [["Security"]]
+  - type: MarketModifier
+    mod: 5
   - type: PointLight
     radius: 1
     energy: 1.2
@@ -775,14 +781,16 @@
     radius: 1.5
     energy: 1.6
     color: "#326e3f"
+  - type: MarketModifier
+    mod: 5
 
 - type: entity
   parent: VendingMachineSeedsUnlocked
   id: VendingMachineSeeds
   suffix: Hyroponics
   components:
-  - type: AccessReader
-    access: [["Hydroponics"]]
+  - type: MarketModifier
+    mod: 5
 
 - type: entity
   parent: VendingMachine
@@ -964,6 +972,8 @@
     radius: 1.5
     energy: 1.6
     color: "#389690"
+  - type: MarketModifier
+    mod: 9.64
 
 - type: entity
   parent: VendingMachine
@@ -1060,8 +1070,8 @@
       shader: unshaded
     - state: panel
       map: ["enum.WiresVisualLayers.MaintenancePanel"]
-  - type: AccessReader
-    access: [["Research"]]
+  - type: MarketModifier
+    mod: 5
   - type: PointLight
     radius: 1.5
     energy: 1.6
@@ -1185,8 +1195,8 @@
     radius: 1.5
     energy: 1.6
     color: "#9dc5c9"
-  - type: AccessReader
-    access: [["Salvage"]]
+  - type: MarketModifier
+    mod: 5
 
 - type: entity
   parent: VendingMachine
@@ -1218,6 +1228,8 @@
     radius: 1.5
     energy: 1.6
     color: "#d4ab33"
+  - type: MarketModifier
+    mod: 5
 
 # wallmounted machines
 
@@ -1258,8 +1270,8 @@
       shader: unshaded
     - texture: Structures/Machines/VendingMachines/maintenance_panel.png
       map: ["enum.WiresVisualLayers.MaintenancePanel"]
-  - type: AccessReader
-    access: [["Medical"]]
+  - type: MarketModifier
+    mod: 5
 
 # job clothing
 
@@ -1286,8 +1298,6 @@
       shader: unshaded
     - state: panel
       map: ["enum.WiresVisualLayers.MaintenancePanel"]
-  - type: AccessReader
-    access: [["Hydroponics"]]
 
 - type: entity
   parent: VendingMachine
@@ -1312,8 +1322,6 @@
       shader: unshaded
     - state: panel
       map: ["enum.WiresVisualLayers.MaintenancePanel"]
-  - type: AccessReader
-    access: [["Brig"]]
 
 - type: entity
   parent: VendingMachine
@@ -1364,8 +1372,6 @@
       shader: unshaded
     - state: panel
       map: ["enum.WiresVisualLayers.MaintenancePanel"]
-  - type: AccessReader
-    access: [["Bar"]]
 
 - type: entity
   parent: VendingMachine
@@ -1388,8 +1394,6 @@
       shader: unshaded
     - state: panel
       map: ["enum.WiresVisualLayers.MaintenancePanel"]
-  - type: AccessReader
-    access: [["Chapel"]]
   - type: PointLight
     radius: 1.5
     energy: 1.6
@@ -1418,8 +1422,6 @@
       shader: unshaded
     - state: panel
       map: ["enum.WiresVisualLayers.MaintenancePanel"]
-  - type: AccessReader
-    access: [["Cargo"]]
 
 - type: entity
   parent: VendingMachine
@@ -1444,8 +1446,6 @@
       shader: unshaded
     - state: panel
       map: ["enum.WiresVisualLayers.MaintenancePanel"]
-  - type: AccessReader
-    access: [["Medical"]]
 
 - type: entity
   parent: VendingMachine
@@ -1470,8 +1470,6 @@
       shader: unshaded
     - state: panel
       map: ["enum.WiresVisualLayers.MaintenancePanel"]
-  - type: AccessReader
-    access: [["Chemistry"]]
 
 - type: entity
   parent: VendingMachine
@@ -1496,8 +1494,6 @@
       shader: unshaded
     - state: panel
       map: ["enum.WiresVisualLayers.MaintenancePanel"]
-  - type: AccessReader
-    access: [["Engineering"]]
 
 - type: entity
   parent: VendingMachine
@@ -1522,8 +1518,6 @@
       shader: unshaded
     - state: panel
       map: ["enum.WiresVisualLayers.MaintenancePanel"]
-  - type: AccessReader
-    access: [["Engineering"]]
 
 - type: entity
   parent: VendingMachine
@@ -1548,8 +1542,6 @@
       shader: unshaded
     - state: panel
       map: ["enum.WiresVisualLayers.MaintenancePanel"]
-  - type: AccessReader
-    access: [["Kitchen"]]
 
 - type: entity
   parent: VendingMachine
@@ -1574,8 +1566,6 @@
       shader: unshaded
     - state: panel
       map: ["enum.WiresVisualLayers.MaintenancePanel"]
-  - type: AccessReader
-    access: [["Security"]]
 
 - type: entity
   parent: VendingMachine
@@ -1600,8 +1590,6 @@
       shader: unshaded
     - state: panel
       map: ["enum.WiresVisualLayers.MaintenancePanel"]
-  - type: AccessReader
-    access: [["Janitor"]]
 
 - type: entity
   parent: VendingMachine
@@ -1626,8 +1614,6 @@
       shader: unshaded
     - state: panel
       map: ["enum.WiresVisualLayers.MaintenancePanel"]
-  - type: AccessReader
-    access: [["Research"]]
 
 - type: entity
   parent: VendingMachine
@@ -1652,8 +1638,6 @@
       shader: unshaded
     - state: panel
       map: ["enum.WiresVisualLayers.MaintenancePanel"]
-  - type: AccessReader
-    access: [["Research"]]
 
 - type: entity
   parent: VendingMachine
@@ -1678,8 +1662,6 @@
       shader: unshaded
     - state: panel
       map: ["enum.WiresVisualLayers.MaintenancePanel"]
-  - type: AccessReader
-    access: [["Medical"]]
 
 - type: entity
   parent: VendingMachine
@@ -1704,8 +1686,6 @@
       shader: unshaded
     - state: panel
       map: ["enum.WiresVisualLayers.MaintenancePanel"]
-  - type: AccessReader
-    access: [["Medical"]]
    
 - type: entity
   parent: VendingMachine
@@ -1765,8 +1745,8 @@
     color: "#3c5eb5"
   - type: Advertise
     pack: HappyHonkAds
-  - type: AccessReader
-    access: [["Kitchen"], ["Theatre"]]
+  - type: MarketModifier
+    mod: 5
 
 # Gas Tank Dispenser
 
@@ -1782,6 +1762,8 @@
   - type: Sprite
     sprite: Structures/Machines/VendingMachines/tankdispenser.rsi #TODO add visualiser for remaining tanks as layers
     state: dispenser
+  - type: MarketModifier
+    mod: 5
 
 - type: entity
   parent: VendingMachine

--- a/Resources/Prototypes/_NF/Entities/Structures/machines.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/machines.yml
@@ -125,3 +125,23 @@
   - type: Appearance
   - type: Climbable
   - type: CryoSleep
+  
+- type: entity
+  id: ComputerPalletConsoleNFHighMarket
+  parent: ComputerPalletConsole
+  suffix: High
+  name: cargo sale computer
+  description: Used to sell goods loaded onto cargo pallets
+  components:
+  - type: MarketModifier
+    mod: 1.707
+  
+- type: entity
+  id: ComputerPalletConsoleNFLowMarket
+  parent: ComputerPalletConsole
+  suffix: Low
+  name: cargo sale computer
+  description: Used to sell goods loaded onto cargo pallets
+  components:
+  - type: MarketModifier
+    mod: 0.892


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
cargo order console and teleporter now run on player bank account instead of the station's. Station bank account now gets a portion of what is purchased from the cargo instead, along with a portion of vending machine sales, and tweaks the market modifier on job vending machines to be cheaper than generic vending machine markup.
