### PR TITLE
add another cargo depot and hide and shrink radius of dungeons

### DIFF
--- a/Content.Server/_NF/GameRule/NfAdventureRuleSystem.cs
+++ b/Content.Server/_NF/GameRule/NfAdventureRuleSystem.cs
@@ -9,6 +9,9 @@ using Robust.Shared.Map;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Map.Components;
+using Content.Shared.Shuttles.Components;
+using Content.Server.Shuttles.Systems;
+using Content.Server.Cargo.Components;
 
 namespace Content.Server.GameTicking.Rules;
 
@@ -23,13 +26,10 @@ public sealed class NfAdventureRuleSystem : GameRuleSystem
     [Dependency] private readonly MapLoaderSystem _map = default!;
     [Dependency] private readonly DungeonSystem _dunGen = default!;
     [Dependency] private readonly IConsoleHost _console = default!;
+    [Dependency] private readonly ShuttleSystem _shuttle = default!;
 
     [ViewVariables]
     private List<(EntityUid, int)> _players = new();
-    [ViewVariables]
-    private MapId _currentWorld = new();
-    [ViewVariables]
-    private int _totalBalance = 0;
 
     public override string Prototype => "Adventure";
 
@@ -72,8 +72,9 @@ public sealed class NfAdventureRuleSystem : GameRuleSystem
         if (ev.Player.AttachedEntity is { Valid : true } mobUid)
         {
             _players.Add((mobUid, ev.Profile.BankBalance));
+            EnsureComp<CargoSellBlacklistComponent>(mobUid);
         }
-
+        
     }
 
     private void OnStartup(RoundStartingEvent ev)
@@ -83,13 +84,22 @@ public sealed class NfAdventureRuleSystem : GameRuleSystem
 
         var depotMap = "/Maps/cargodepot.yml";
         var mapId = GameTicker.DefaultMap;
+        var depotOffset = _random.NextVector2(1500f, 3000f);
         if (_map.TryLoad(mapId, depotMap, out var depotUids, new MapLoadOptions
         {
-            Offset = _random.NextVector2(1500f, 3500f)
+            Offset = depotOffset
         }))
         {
             var meta = EnsureComp<MetaDataComponent>(depotUids[0]);
-            meta.EntityName = "NT Cargo Depot NF14";
+            meta.EntityName = "NT Cargo Depot A NF14";
+        };
+        if (_map.TryLoad(mapId, depotMap, out var depotUid2s, new MapLoadOptions
+        {
+            Offset = -depotOffset
+        }))
+        {
+            var meta = EnsureComp<MetaDataComponent>(depotUid2s[0]);
+            meta.EntityName = "NT Cargo Depot B NF14";
         };
 
         var dungenTypes = _prototypeManager.EnumeratePrototypes<DungeonConfigPrototype>();
@@ -98,7 +108,7 @@ public sealed class NfAdventureRuleSystem : GameRuleSystem
         {
 
             var seed = _random.Next();
-            var offset = _random.NextVector2(3500f, 6000f);
+            var offset = _random.NextVector2(1500f, 3500f);
             if (!_map.TryLoad(mapId, "/Maps/spaceplatform.yml", out var grids, new MapLoadOptions
             {
                 Offset = offset
@@ -108,10 +118,13 @@ public sealed class NfAdventureRuleSystem : GameRuleSystem
             }
 
             var mapGrid = EnsureComp<MapGridComponent>(grids[0]);
+            _shuttle.AddIFFFlag(grids[0], IFFFlags.HideLabel);
             _console.WriteLine(null, $"dungeon spawned at {offset}");
             offset = new Vector2 (0, 0);
 
             //pls fit the grid I beg, this is so hacky
+            //its better now but i think i need to do a normalization pass on the dungeon configs
+            //because they are all offset
             _dunGen.GenerateDungeon(dunGen, grids[0], mapGrid, offset, seed);
         }
     }

--- a/Resources/Prototypes/World/Biomes/basic.yml
+++ b/Resources/Prototypes/World/Biomes/basic.yml
@@ -7,7 +7,7 @@
       densityNoiseChannel: Density
     - type: SimpleDebrisSelector
       debrisTable:
-        - id: CitadelAsteroidDebrisSmall
+        ##- id: CitadelAsteroidDebrisSmall
         - id: CitadelAsteroidDebrisMedium
         - id: CitadelAsteroidDebrisLarge
           prob: 0.7
@@ -16,9 +16,10 @@
     - type: NoiseDrivenDebrisSelector
       noiseChannel: Wreck
       debrisTable:
-        - id: CitadelScrapDebrisSmall
+        ##- id: CitadelScrapDebrisSmall
         - id: CitadelScrapDebrisMedium
         - id: CitadelScrapDebrisLarge
+        - id: CitadelAsteroidDebrisLarger
           prob: 0.5
     - type: NoiseRangeCarver
       ranges:

--- a/Resources/Prototypes/World/Biomes/failsafes.yml
+++ b/Resources/Prototypes/World/Biomes/failsafes.yml
@@ -12,7 +12,7 @@
       densityNoiseChannel: Density
     - type: SimpleDebrisSelector
       debrisTable:
-        - id: CitadelAsteroidDebrisSmall
+        ##- id: CitadelAsteroidDebrisSmall
         - id: CitadelAsteroidDebrisMedium
         - id: CitadelAsteroidDebrisLarge
           prob: 0.7


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
changes locations of cargo depot, adds another
shrinks the radius of dungeon spawn locations to 1500-3500 but hides their IFF
modifies world gen to not make tiny invisible wrecks that you cant see on console